### PR TITLE
fix: show blog posts on blog listing

### DIFF
--- a/themes/aurora-dark/layouts/search/section.json
+++ b/themes/aurora-dark/layouts/search/section.json
@@ -1,4 +1,6 @@
-{{- $pages := where site.RegularPages "Type" "in" site.Params.search.indexSections -}}
+{{- $site := .Site -}}
+{{- $indexSections := $site.Params.search.indexSections | default (slice) -}}
+{{- $pages := where $site.RegularPages "Type" "in" $indexSections -}}
 {{- $data := slice -}}
 {{- range $pages -}}
   {{- $doc := dict "title" .Title "summary" (.Summary | plainify) "permalink" .RelPermalink "tags" .Params.tags "section" .Section -}}


### PR DESCRIPTION
## Summary
- scope the search index to the active language's site context so localized pages are indexed correctly

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d591d7c47083249f2585b041f5de49