### PR TITLE
Render travel landing content

### DIFF
--- a/themes/aurora-dark/layouts/travel/list.html
+++ b/themes/aurora-dark/layouts/travel/list.html
@@ -73,5 +73,10 @@
     {{ if not (gt (len $pages) 0) }}
       <p>{{ i18n "noEntries" }}</p>
     {{ end }}
+    {{ with .Content }}
+      <div class="content">
+        {{ . }}
+      </div>
+    {{ end }}
   </section>
 {{ end }}


### PR DESCRIPTION
## Summary
- render the Travel landing page body content below the interactive map
- ensure markdown copy is displayed when present on the travel index

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5af9ea9848324a08b8944643a9c5d