### PR TITLE
Add German translations for blog, travel, and project content

### DIFF
--- a/content/de/blog/aws-multi-account-operating-model.md
+++ b/content/de/blog/aws-multi-account-operating-model.md
@@ -1,0 +1,18 @@
+---
+title: "Ein AWS-Betriebsmodell für viele Accounts entwerfen"
+date: 2024-05-30
+summary: "Von Guardrails bis Enablement: Praktiken, die Plattform- und Produktteams in Einklang halten."
+tags: ["aws", "cloud", "operating model"]
+categories: ["Cloud"]
+cover: "/images/aws-operating-model.svg"
+type: "post"
+affiliate_disclosure: false
+---
+
+Die Skalierung von AWS über 40+ Teams zwang uns, Governance und Autonomie neu zu denken. Wir entwickelten ein Multi-Account-Blueprint, verankert in drei Ebenen:
+
+1. **Fundamentale Guardrails.** AWS Control Tower plus angepasste Service Control Policies sichern Baselines und Kostentagging.
+2. **Enablement-Plattform.** Ein Golden Path aus Terraform-Modulen, Backstage-Templates und automatisiertem Account-Vending bringt Teams in unter 30 Minuten an den Start.
+3. **Geteilte Verantwortung.** Ein leichtgewichtiger Cloud Council nutzt Scorecards, um Zuverlässigkeit, Kosten und Delivery-Gesundheit monatlich zu prüfen.
+
+Der Blueprint hält Experimentierfreude lebendig, ohne Compliance zu gefährden.

--- a/content/de/blog/aws-serverless-observability.md
+++ b/content/de/blog/aws-serverless-observability.md
@@ -1,0 +1,20 @@
+---
+title: "Serverless-Observability auf AWS ohne Rauschen"
+date: 2024-06-18
+summary: "Event-getriebene Workloads mit klaren SLOs und handlungsleitenden Alerts instrumentieren."
+tags: ["aws", "cloud", "observability"]
+categories: ["Cloud"]
+cover: "/images/aws-observability.svg"
+type: "post"
+affiliate_disclosure: false
+---
+
+Ich habe ein Produktteam beim Wechsel von EC2-lastigen Analysejobs zu einem ereignisgetriebenen Stack auf Lambda, Step Functions und Kinesis begleitet. Observability wurde zum entscheidenden Faktor.
+
+Der Fahrplan:
+
+- **Alles tracen.** AWS Distro for OpenTelemetry sendet Spans in einen OpenSearch-Cluster mit kuratierten Dashboards.
+- **Metrik-SLOs.** Kundenreisen werden auf Latenz-SLOs gemappt – gestützt auf CloudWatch Metrics und Synthetics.
+- **On-Call-Klarheit.** Alerts laufen über Opsgenie, Runbooks liegen versioniert in Git-Playbooks.
+
+Das Ergebnis: Das Signal-Rausch-Verhältnis stieg um 42 %, und die Rufbereitschaft bekam ihre Wochenenden zurück.

--- a/content/de/blog/dark-mode-color-systems.md
+++ b/content/de/blog/dark-mode-color-systems.md
@@ -1,0 +1,18 @@
+---
+title: "Farbsysteme für Premium-Dark-Themes"
+date: 2024-07-12
+summary: "Zugängliche, kontrastreiche Paletten für dunkle Experiences bauen, ohne Wärme zu verlieren."
+tags: ["web design", "a11y", "design systems"]
+categories: ["Design"]
+cover: "/images/color-system.svg"
+type: "post"
+affiliate_disclosure: false
+---
+
+Design für dunkle Oberflächen heißt, Kontrastwerte mit atmosphärischer Nuance auszubalancieren. Ich beginne mit Luminanz-Leitern, die WCAG 2.1 AA erfüllen, und ergänze Akzentfarben mit enger Sättigungskontrolle.
+
+- **Neutraltöne zuerst.** Eine Grauskala, die lesbaren Text und zurückhaltende UI-Elemente trägt.
+- **Akzentverläufe.** Zwei-Ton-Verläufe für Hero-Flächen, deren hellster Wert weiterhin ausreichend Kontrast zu Weiß bietet.
+- **Test-Set.** Kontrast-Checker, Device-Previews und das neue CSS `color-mix()` beschleunigen State-Previews.
+
+Dunkle Themes können hochwertig wirken und hervorragend performen, wenn sie die menschliche Wahrnehmung in den Mittelpunkt stellen.

--- a/content/de/blog/hydrofoil-learning-journal.md
+++ b/content/de/blog/hydrofoil-learning-journal.md
@@ -1,0 +1,18 @@
+---
+title: "Hydrofoil-Lerntagebuch"
+date: 2024-04-22
+summary: "Kaizen-Prinzipien nutzen, um Balance, Nickwinkel und Geduld zu meistern."
+tags: ["kitesurfen", "lernen", "coaching"]
+categories: ["Abenteuer"]
+cover: "/images/hydrofoil.svg"
+type: "post"
+affiliate_disclosure: false
+---
+
+Foilen erdet. Jede Mikro-Anpassung wirkt verstärkt, also habe ich den Prozess in einen Feedback-Loop aus dem Engineering-Alltag verwandelt.
+
+1. **Hypothese definieren.** Beispiel: Früheres Gewichtsverlagern nach vorne reduziert Touchdowns.
+2. **Instrumentieren.** GoPro-Aufnahmen plus GPS-Geschwindigkeits-Overlays zeigen, was Intuition übersieht.
+3. **Retro.** Nach jedem Set Lektionen in Notion festhalten und den nächsten Versuch planen.
+
+Der Fortschritt ist langsam, aber messbar – und der erste stabile Glide fühlt sich an wie ein fehlerfreier Produktions-Release.

--- a/content/de/blog/kitesurfing-baltic-playbook.md
+++ b/content/de/blog/kitesurfing-baltic-playbook.md
@@ -1,0 +1,18 @@
+---
+title: "Ostsee-Kitesurfing-Playbook"
+date: 2024-06-05
+summary: "Gezeiten lesen, Böen timen und sicher über die flachen Bänke der Ostsee gleiten."
+tags: ["kitesurfen", "reise", "sicherheit"]
+categories: ["Abenteuer"]
+cover: "/images/kitesurf-baltic.svg"
+type: "post"
+affiliate_disclosure: false
+---
+
+Ostsee-Spots belohnen Geduld. Sandbänke wandern wöchentlich und der Wind springt in einer Session von 12 auf 28 Knoten. Mein Playbook umfasst:
+
+- **Gezeiten-Tabellen und Lotungen**, die mit meinem Garmin inReach synchronisiert sind.
+- **Crew-Checks**, die den Incident-Response-Ritualen aus der Luftfahrt folgen.
+- **Mikro-Retros** nach jedem Run: Was lief gut, was wird angepasst?
+
+Dasselbe Systemdenken aus dem Platform-Engineering hält Sessions sicher und macht sie zugleich spielerisch.

--- a/content/de/blog/split-identity-hero.md
+++ b/content/de/blog/split-identity-hero.md
@@ -1,0 +1,20 @@
+---
+title: "Einen Split-Identity-Hero gestalten"
+date: 2024-08-01
+summary: "Zwei Erzählstränge für IT-Führung und Segelabenteuer ausbalancieren, ohne Besucher zu überfordern."
+tags: ["web design", "ux", "dark mode"]
+categories: ["Design"]
+cover: "/images/hero-concept.svg"
+type: "post"
+affiliate_disclosure: false
+---
+
+Der Hero dieser Seite sollte zwei Narrative tragen: Beratung in komplexen IT-Landschaften und das Leben auf See. Statt sie zu stapeln, erzeugt der Split-Identity-Hero Spannung und Klarheit.
+
+Die wichtigsten Kniffe:
+
+1. **Kontrastierende Panels.** Eine Seite setzt auf tiefes Blau und strukturierte Typografie. Die andere nutzt weiche Verläufe und organische Formen, um Bewegung anzudeuten.
+2. **Gemeinsamer Anker.** Die Tagline bleibt zentriert und verbindet beide Welten. So wird klar, dass ich in beiden Domänen mit derselben Haltung arbeite.
+3. **Zugängliche Motion.** Animationen respektieren `prefers-reduced-motion`. Besucher erhalten subtile Hinweise ohne Ablenkung.
+
+Das Ergebnis: ein Hero, der wie eine lebendige Einführung wirkt – nicht nur wie ein Banner.

--- a/content/de/blog/travel-sardinia-ports.md
+++ b/content/de/blog/travel-sardinia-ports.md
@@ -1,0 +1,20 @@
+---
+title: "Sardinien-Hafennotizen"
+date: 2024-05-15
+summary: "Von Olbia bis Alghero: kulturelle Stopps und Crew-Rituale entlang der Route."
+tags: ["reise", "segeln", "kultur"]
+categories: ["Travel"]
+cover: "/images/sardinia-route.svg"
+type: "post"
+affiliate_disclosure: false
+---
+
+Sardinien entfaltet seinen Charme im langsameren Tempo. Wir planten längere Stopps, um lokale Kooperativen kennenzulernen und Lieferketten für die Verproviantierung zu kartieren.
+
+Highlights:
+
+- **Märkte in Olbia**, wo wir saisonale Produkte kauften und mit Händler*innen über Plattform-Analogien sprachen.
+- **La Maddalena-Archipel** für Tidennavigations-Drills.
+- **Retros in Alghero** auf einer Dachterrasse – Crew-Check-ins kombiniert mit Storytelling.
+
+Jeder Hafen wird zum Klassenzimmer, wenn Neugier den Kurs vorgibt.

--- a/content/de/blog/travel-tech-map-automation.md
+++ b/content/de/blog/travel-tech-map-automation.md
@@ -1,0 +1,18 @@
+---
+title: "Reisekarten automatisieren"
+date: 2024-04-10
+summary: "GPS-Tracks, Journale und Kulturrecherche in einer lebendigen Karte zusammenführen."
+tags: ["reise", "automation", "karten"]
+categories: ["Travel"]
+cover: "/images/travel-map-automation.svg"
+type: "post"
+affiliate_disclosure: false
+---
+
+Die Reisekarte auf dieser Seite baut sich aus strukturierten Inhalten und GPS-Logs selbst. So funktioniert die Pipeline:
+
+- **Log-Erfassung.** Garmin inReach exportiert nach jeder Passage CSV-Dateien.
+- **Transformation.** Ein kleines Python-Skript wandelt Tracks in GeoJSON um und reichert Einträge mit Tags an.
+- **Publishing.** Hugo liest die Daten über Front Matter und `data/travel.yaml` ein und rendert Marker mit Leaflet.
+
+Automatisierung hält das Storytelling frisch und schafft Zeit für echte Erkundung.

--- a/content/de/projects/crew-ops-canvas.md
+++ b/content/de/projects/crew-ops-canvas.md
@@ -1,0 +1,12 @@
+---
+title: "Crew Ops Canvas"
+date: 2024-03-12
+summary: "Ein Facilitation-Toolkit, das Segelrituale in Teamvereinbarungen übersetzt."
+type: "project"
+repo: "https://github.com/yourhandle/crew-ops-canvas"
+tech: ["Hugo", "Netlify", "Figma"]
+status: "beta"
+external: "https://crew-ops.example.com"
+---
+
+Das Canvas kombiniert Moderationsimpulse mit Fallstudien aus der Praxis. In Workshops hilft es Teams, Rollen, Signale und Eskalationspfade zu klären.

--- a/content/de/projects/sailing-logger.md
+++ b/content/de/projects/sailing-logger.md
@@ -1,0 +1,12 @@
+---
+title: "Sailing Logger"
+date: 2024-02-05
+summary: "Ein Go-basiertes ETL, das GPS-Tracks in strukturierte Reiseinhalte überführt."
+type: "project"
+repo: "https://github.com/yourhandle/sailing-logger"
+tech: ["Go", "AWS Lambda", "S3", "PostgreSQL"]
+status: "stable"
+external: "https://demo.example.com/logger"
+---
+
+Der Logger ingestiert GPX-Dateien, reichert sie mit Wetter-Metadaten an und erzeugt Markdown-Skelette, die das Storytelling beschleunigen. Eine zustimmungsbasierte Retention-Policy ist integriert.

--- a/content/de/travel/azores-volcanic-loop.md
+++ b/content/de/travel/azores-volcanic-loop.md
@@ -1,0 +1,23 @@
+---
+title: "Azoren: Vulkanischer Loop"
+date: 2024-05-08
+summary: "São-Miguel-Thermen mit Pico-Weinbergen per Inselhopping verbinden."
+type: "travel"
+country: "Portugal"
+city: "Horta"
+visited_at: 2024-04-28
+map_zoom: 7
+gps:
+  lat: 38.5333
+  lng: -28.6260
+hero: "/images/azores-loop.svg"
+tags: ["segeln", "kultur", "azoren"]
+---
+
+Wir segelten einen Uhrzeigersinn-Loop durch das zentrale Inseldreieck der Azoren und kombinierten vulkanische Wanderungen mit Crew-Endurance-Drills.
+
+- **Ponta Delgada** bot Proviant und ein Briefing mit lokalen Meteorolog*innen.
+- **Furnas-Thermen** dienten als Regeneration nach Nachtfahrten.
+- **Pico-Weinberge** demonstrierten Resilience Engineering live – Steinmauern schützen Reben wie Blast Walls.
+
+Im Peter Café Sport in Horta fand die Abschluss-Retro statt – mit Gin do Mar und neuen Routenskizzen.

--- a/content/de/travel/sognefjord-night-sail.md
+++ b/content/de/travel/sognefjord-night-sail.md
@@ -1,0 +1,23 @@
+---
+title: "Nachtfahrt in den Sognefjord"
+date: 2024-06-28
+summary: "Norwegische Fjordlichter mit frisch trainierter Crew navigieren."
+type: "travel"
+country: "Norwegen"
+city: "Balestrand"
+visited_at: 2024-06-22
+map_zoom: 8
+gps:
+  lat: 61.2006
+  lng: 6.5340
+hero: "/images/sognefjord-night.svg"
+tags: ["segeln", "navigation", "norwegen"]
+---
+
+Wir liefen bei Sonnenuntergang in Bergen aus, um den Stillwasser-Zeitpunkt am Fjordeingang zu treffen. Die Crew rotierte alle 30 Minuten zwischen Radar, AIS und Ausguck. Balestrand begrüßte uns um 03:30 Uhr mit Pastellhimmel.
+
+Highlights:
+
+- Stille Kommandos geübt, damit die Off-Watch-Crew schlafen konnte.
+- Wegpunkt-Notizen direkt ins Nav-Tablet eingetragen, damit der Travel-Map-Sync greift.
+- Nach dem Anlegen mit Zimtschnecken und lokalen Geschichtslektionen debriefed.

--- a/content/de/travel/spiekeroog-soundings.md
+++ b/content/de/travel/spiekeroog-soundings.md
@@ -1,0 +1,17 @@
+---
+title: "Lotungen vor Spiekeroog"
+date: 2024-03-19
+summary: "Flache Bänke kartieren und Manöver-Drills für den Katamaran testen."
+type: "travel"
+country: "Deutschland"
+city: "Spiekeroog"
+visited_at: 2024-03-12
+map_zoom: 9
+gps:
+  lat: 53.7700
+  lng: 7.7000
+hero: "/images/sailing-baltic.svg"
+tags: ["segeln", "deutschland"]
+---
+
+Die Nordsee-Gezeiten modellieren die Priele alle paar Tage neu, also verbrachten wir eine Woche mit dem Kalibrieren der Echolote und Kurzkehren in engen Fahrwassern. Der geringe Tiefgang des Katamarans ermöglichte Abstecher in Priele, die Einrumpfboote meiden.


### PR DESCRIPTION
## Summary
- add german blog posts to mirror each english article with localized summaries and body copy
- extend the german travel section with localized itineraries and matching metadata
- localize remaining project descriptions so the german portfolio matches english content

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5b8d980788324844010f28095c4fd