### PR TITLE
Refine homepage hero and blog listing

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -56,4 +56,20 @@
   translation: "Zertifizierungen"
 - id: noEntries
   translation: "Noch keine Einträge verfügbar."
+- id: heroTechTitle
+  translation: "IT-Strategie & Cloud-Führung"
+- id: heroTechLead
+  translation: "Ich gestalte moderne Plattformen, die Teams ausrichten und verlässliche Lieferung ermöglichen."
+- id: heroTechMeta
+  translation: "Lass uns über Transformation, Führung und pragmatische Roadmaps sprechen."
+- id: heroTechCta
+  translation: "Über Manuel"
+- id: heroSailTitle
+  translation: "Segeln, Reisen & kulturelle Neugier"
+- id: heroSailLead
+  translation: "Ich segle Blauwasser-Törns und teile die Lektionen, die Gezeiten und Crews vermitteln."
+- id: heroSailMeta
+  translation: "Verfolge neue Logbucheinträge, Routen und kulturelle Entdeckungen jeder Passage."
+- id: heroSailCta
+  translation: "Reisekarte"
 

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -56,3 +56,19 @@
   translation: "Certifications"
 - id: noEntries
   translation: "No entries available yet."
+- id: heroTechTitle
+  translation: "IT Strategy & Cloud Leadership"
+- id: heroTechLead
+  translation: "Shaping modern platforms that keep teams aligned and delivery resilient."
+- id: heroTechMeta
+  translation: "Let's connect on transformation, leadership, and pragmatic roadmaps."
+- id: heroTechCta
+  translation: "About Manuel"
+- id: heroSailTitle
+  translation: "Sailing, Travel & Cultural Curiosity"
+- id: heroSailLead
+  translation: "Charting bluewater voyages and sharing the lessons tides and crews teach."
+- id: heroSailMeta
+  translation: "Follow new log entries, routes, and cultural finds from each passage."
+- id: heroSailCta
+  translation: "Travel map"

--- a/themes/aurora-dark/assets/css/main.css
+++ b/themes/aurora-dark/assets/css/main.css
@@ -329,7 +329,7 @@ header.site-header .container {
 .hero-content {
   position: relative;
   z-index: 1;
-  padding: clamp(2.75rem, 6vw, 4.5rem) clamp(1.75rem, 6vw, 5rem) clamp(3.5rem, 7vw, 5rem);
+  padding: clamp(2.25rem, 5vw, 3.75rem) clamp(1.5rem, 5vw, 4rem) clamp(3rem, 6vw, 4.25rem);
   background: linear-gradient(180deg, rgba(11, 15, 20, 0.98) 0%, rgb(8, 15, 24) 100%);
   border-top: 1px solid rgba(127, 176, 255, 0.14);
   box-shadow: 0 -24px 48px rgba(4, 10, 18, 0.55);
@@ -338,14 +338,14 @@ header.site-header .container {
 .hero-columns {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: clamp(2rem, 5vw, 4rem);
+  gap: clamp(1.5rem, 4vw, 3rem);
   align-items: start;
 }
 
 .hero-column {
   display: grid;
-  gap: 1.25rem;
-  max-width: 520px;
+  gap: 1rem;
+  max-width: 480px;
 }
 
 .hero-column-tech {
@@ -364,11 +364,12 @@ header.site-header .container {
 
 .hero-column p {
   color: color-mix(in srgb, var(--color-text-muted) 80%, var(--color-text));
-  font-size: 1.05rem;
+  font-size: 1rem;
+  line-height: 1.5;
 }
 
 .hero-column .hero-meta {
-  gap: 1rem;
+  gap: 0.75rem;
   align-content: start;
 }
 

--- a/themes/aurora-dark/assets/scss/main.scss
+++ b/themes/aurora-dark/assets/scss/main.scss
@@ -340,7 +340,7 @@ header.site-header .container {
 .hero-content {
   position: relative;
   z-index: 1;
-  padding: clamp(2.75rem, 6vw, 4.5rem) clamp(1.75rem, 6vw, 5rem) clamp(3.5rem, 7vw, 5rem);
+  padding: clamp(2.25rem, 5vw, 3.75rem) clamp(1.5rem, 5vw, 4rem) clamp(3rem, 6vw, 4.25rem);
   background: linear-gradient(180deg, rgba(11, 15, 20, 0.98) 0%, rgba(8, 15, 24, 1) 100%);
   border-top: 1px solid rgba(127, 176, 255, 0.14);
   box-shadow: 0 -24px 48px rgba(4, 10, 18, 0.55);
@@ -349,14 +349,14 @@ header.site-header .container {
 .hero-columns {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: clamp(2rem, 5vw, 4rem);
+  gap: clamp(1.5rem, 4vw, 3rem);
   align-items: start;
 }
 
 .hero-column {
   display: grid;
-  gap: 1.25rem;
-  max-width: 520px;
+  gap: 1rem;
+  max-width: 480px;
 }
 
 .hero-column-tech {
@@ -375,11 +375,12 @@ header.site-header .container {
 
 .hero-column p {
   color: color-mix(in srgb, var(--color-text-muted) 80%, var(--color-text));
-  font-size: 1.05rem;
+  font-size: 1rem;
+  line-height: 1.5;
 }
 
 .hero-column .hero-meta {
-  gap: 1rem;
+  gap: 0.75rem;
   align-content: start;
 }
 

--- a/themes/aurora-dark/layouts/index.html
+++ b/themes/aurora-dark/layouts/index.html
@@ -23,21 +23,19 @@
     <div class="hero-content">
       <div class="hero-columns">
         <div class="hero-column hero-column-tech">
-          <span class="badge">IT Transformation</span>
-          <h2>IT Strategy &amp; Cloud Leadership</h2>
-          <p>Guiding organizations through cloud-native modernization, platform strategy, and resilient delivery models.</p>
+          <h2>{{ i18n "heroTechTitle" }}</h2>
+          <p>{{ i18n "heroTechLead" }}</p>
           <div class="hero-meta">
-            <p>Partner with teams to architect resilient delivery models, accelerate transformation, and tie technology decisions to measurable outcomes.</p>
-            <a class="button button-primary" href="{{ "/services/" | relLangURL }}">Services</a>
+            <p>{{ i18n "heroTechMeta" }}</p>
+            <a class="button button-primary" href="{{ "/about/" | relLangURL }}">{{ i18n "heroTechCta" }}</a>
           </div>
         </div>
         <div class="hero-column hero-column-sailing">
-          <span class="badge">Sailing log</span>
-          <h2>Sailing, Travel &amp; Cultural Curiosity</h2>
-          <p>Skippering bluewater adventures while documenting winds, waypoints, and global cultures that shape resilient leadership.</p>
+          <h2>{{ i18n "heroSailTitle" }}</h2>
+          <p>{{ i18n "heroSailLead" }}</p>
           <div class="hero-meta">
-            <p>Explore the latest travel stories, routes, and cultural notes plotted on the interactive map.</p>
-            <a class="button button-ghost" href="{{ "/travel/" | relLangURL }}">Travel map</a>
+            <p>{{ i18n "heroSailMeta" }}</p>
+            <a class="button button-ghost" href="{{ "/travel/" | relLangURL }}">{{ i18n "heroSailCta" }}</a>
           </div>
         </div>
       </div>
@@ -49,7 +47,7 @@
   {{ if and (ne $lang $defaultLang) (lt (len $latestLocalized) 1) }}
     {{ $latestLocalized = where $allPosts "Lang" $defaultLang }}
   {{ end }}
-  {{ $latestPosts := first 6 $latestLocalized }}
+  {{ $latestPosts := first 1 $latestLocalized }}
   <section class="section" aria-labelledby="recent-posts">
     <div class="container">
       <div class="section-header">


### PR DESCRIPTION
## Summary
- Localize the homepage hero columns, shorten the copy to single-sentence blurbs, and link the IT section to the about page.
- Remove the hero badges, tighten the hero layout spacing, and limit the blog list to the most recent post in each language.

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d5c43b6e4483248162044c7b457a3f