### PR TITLE
Refresh home hero copy and tighten spacing

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -65,10 +65,10 @@
 - id: heroTechCta
   translation: "About Manuel"
 - id: heroSailTitle
-  translation: "Sailing, Travel & Cultural Curiosity"
+  translation: "Sailing, Travel & Technology"
 - id: heroSailLead
-  translation: "Charting bluewater voyages and sharing the lessons tides and crews teach."
+  translation: "Charting bluewater voyages and sharing lessons from every passage."
 - id: heroSailMeta
-  translation: "Follow new log entries, routes, and cultural finds from each passage."
+  translation: "Track fresh log entries, streamlined routes, and discoveries along the way."
 - id: heroSailCta
   translation: "Travel map"

--- a/themes/aurora-dark/assets/css/main.css
+++ b/themes/aurora-dark/assets/css/main.css
@@ -226,7 +226,7 @@ header.site-header .container {
 .hero-split {
   display: flex;
   flex-direction: column;
-  min-height: calc(100vh - var(--header-height));
+  min-height: calc(88vh - var(--header-height));
   width: 100%;
 }
 
@@ -234,7 +234,7 @@ header.site-header .container {
   position: relative;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  min-height: clamp(520px, 72vh, 820px);
+  min-height: clamp(420px, 60vh, 680px);
   isolation: isolate;
 }
 
@@ -329,7 +329,7 @@ header.site-header .container {
 .hero-content {
   position: relative;
   z-index: 1;
-  padding: clamp(2.25rem, 5vw, 3.75rem) clamp(1.5rem, 5vw, 4rem) clamp(3rem, 6vw, 4.25rem);
+  padding: clamp(1.85rem, 4vw, 3rem) clamp(1.5rem, 5vw, 4rem) clamp(2.25rem, 5vw, 3.25rem);
   background: linear-gradient(180deg, rgba(11, 15, 20, 0.98) 0%, rgb(8, 15, 24) 100%);
   border-top: 1px solid rgba(127, 176, 255, 0.14);
   box-shadow: 0 -24px 48px rgba(4, 10, 18, 0.55);
@@ -387,14 +387,14 @@ header.site-header .container {
 }
 
 .section {
-  padding: 4rem 0;
+  padding: 2.75rem 0;
 }
 
 .section-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 2.5rem;
+  margin-bottom: 1.75rem;
 }
 
 .section-title {
@@ -409,7 +409,7 @@ header.site-header .container {
 
 .card-grid {
   display: grid;
-  gap: 1.75rem;
+  gap: 1.25rem;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 

--- a/themes/aurora-dark/assets/scss/main.scss
+++ b/themes/aurora-dark/assets/scss/main.scss
@@ -235,7 +235,7 @@ header.site-header .container {
 .hero-split {
   display: flex;
   flex-direction: column;
-  min-height: calc(100vh - var(--header-height));
+  min-height: calc(88vh - var(--header-height));
   width: 100%;
 }
 
@@ -243,7 +243,7 @@ header.site-header .container {
   position: relative;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  min-height: clamp(520px, 72vh, 820px);
+  min-height: clamp(420px, 60vh, 680px);
   isolation: isolate;
 }
 
@@ -340,7 +340,7 @@ header.site-header .container {
 .hero-content {
   position: relative;
   z-index: 1;
-  padding: clamp(2.25rem, 5vw, 3.75rem) clamp(1.5rem, 5vw, 4rem) clamp(3rem, 6vw, 4.25rem);
+  padding: clamp(1.85rem, 4vw, 3rem) clamp(1.5rem, 5vw, 4rem) clamp(2.25rem, 5vw, 3.25rem);
   background: linear-gradient(180deg, rgba(11, 15, 20, 0.98) 0%, rgba(8, 15, 24, 1) 100%);
   border-top: 1px solid rgba(127, 176, 255, 0.14);
   box-shadow: 0 -24px 48px rgba(4, 10, 18, 0.55);
@@ -398,14 +398,14 @@ header.site-header .container {
 }
 
 .section {
-  padding: 4rem 0;
+  padding: 2.75rem 0;
 }
 
 .section-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 2.5rem;
+  margin-bottom: 1.75rem;
 }
 
 .section-title {
@@ -420,7 +420,7 @@ header.site-header .container {
 
 .card-grid {
   display: grid;
-  gap: 1.75rem;
+  gap: 1.25rem;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 


### PR DESCRIPTION
## Summary
- update the sailing hero copy to highlight technology and sharpen the supporting text
- reduce hero and section spacing so the home page stacks more tightly

## Testing
- npm run build:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5cf89868c8324a97c4526c147326f